### PR TITLE
Fix: Add necessary props to Link component

### DIFF
--- a/src/components/PostSnippet/index.js
+++ b/src/components/PostSnippet/index.js
@@ -5,7 +5,7 @@ import * as S from './styles'
 export default function PostSnippet ({ slug, frontMatter }) {
   return (
     <>
-      <Link href={slug}>
+      <Link href="/[slug]" as={slug} passHref>
         <a style={{
           fontSize: '25px',
           textDecoration: 'none',

--- a/src/components/PostSnippet/index.js
+++ b/src/components/PostSnippet/index.js
@@ -5,7 +5,7 @@ import * as S from './styles'
 export default function PostSnippet ({ slug, frontMatter }) {
   return (
     <>
-      <Link href="/[slug]" as={slug} passHref>
+      <Link href='/[slug]' as={slug} passHref>
         <a style={{
           fontSize: '25px',
           textDecoration: 'none',


### PR DESCRIPTION
(Caught this one in my own site and thought I'd submit a PR, too!)

As per https://nextjs.org/docs/api-reference/next/link#dynamic-routes, dynamic routes should have both `href` and `as`.

```jsx
// Example from the docs
<Link href="/post/[pid]" as="/post/abc">
  <a>First Post</a>
</Link>
```

I also added `passHref` so the `href` attribute gets rendered to the markup and does not rely on client-side hydration.