### PR TITLE
New fonts prop passable to SEO to preload fonts from an API

### DIFF
--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -1,18 +1,18 @@
 import * as S from './styles'
 import { Width } from 'components'
-import siteMetadata from 'siteMetadata'
+import siteConfig from 'site.config'
 
 const Footer = props => (
   <Width {...props}>
     <S.Footer>
       <S.Copyright>
-        © {new Date().getFullYear()} {siteMetadata.author}
+        © {new Date().getFullYear()} {siteConfig.author}
       </S.Copyright>
       <S.Social>
-        <S.A href={`https://twitter.com/${siteMetadata.twitterHandle}`}>
+        <S.A href={`https://twitter.com/${siteConfig.twitterHandle}`}>
           <S.StyledTwitter />
         </S.A>
-        <S.A href={`https://github.com/${siteMetadata.githubUsername}`}>
+        <S.A href={`https://github.com/${siteConfig.githubUsername}`}>
           <S.StyledGitHub />
         </S.A>
       </S.Social>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import siteMetadata from 'siteMetadata'
+import siteConfig from 'site.config'
 import styled from 'styled-components'
 
 import { Width } from 'components'
@@ -51,7 +51,7 @@ const Header = props => (
         <A>
           <Wordmark>
             <Logo>🌱</Logo>
-            <Name>{siteMetadata.author}</Name>
+            <Name>{siteConfig.author}</Name>
           </Wordmark>
         </A>
       </Link>

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -8,11 +8,25 @@ export default function SEO ({
   twitterHandle,
   favicon,
   ogImage,
-  url
+  url,
+  fonts = [
+    {
+      url:
+        'https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap'
+    }
+  ]
 }) {
+  const Fonts = () =>
+    fonts.map(font => <link href={font.url} rel='preload' as='font' />)
+
   return (
     <Head>
       <title>{title}</title>
+
+      <link rel='icon' href={favicon} />
+
+      <Fonts />
+
       <meta property='og:title' content={title} />
       <meta property='og:description' content={description} />
       <meta property='og:image' content={`${url}${ogImage}`} />
@@ -20,12 +34,7 @@ export default function SEO ({
       <meta property='og:image:height' content='630' />
       <meta name='twitter:site' content={twitterHandle} />
       <meta name='twitter:card' content='summary_large_image' />
-      <link rel='icon' href={favicon} />
       <meta name='twitter:image' content={`${url}${ogImage}`} />
-      <link
-        href='https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap'
-        rel='stylesheet'
-      />
     </Head>
   )
 }

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -1,6 +1,6 @@
 import Head from 'next/head'
 
-import siteMetadata from 'siteMetadata'
+import siteConfig from 'site.config'
 
 export default function SEO ({
   title,
@@ -9,12 +9,7 @@ export default function SEO ({
   favicon,
   ogImage,
   url,
-  fonts = [
-    {
-      url:
-        'https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap'
-    }
-  ]
+  fonts
 }) {
   const Fonts = () =>
     fonts.map(font => <link href={font.url} rel='preload' as='font' />)
@@ -40,5 +35,5 @@ export default function SEO ({
 }
 
 SEO.defaultProps = {
-  ...siteMetadata
+  ...siteConfig
 }

--- a/src/site.config.js
+++ b/src/site.config.js
@@ -7,5 +7,11 @@ export default {
   author: 'Your Name',
   favicon: '/favicon.png',
   ogImage: '/ogImage.png',
-  url: 'https://next-mdx.warner.codes'
+  url: 'https://next-mdx.warner.codes',
+  fonts: [
+    {
+      url:
+        'https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap'
+    }
+  ]
 }


### PR DESCRIPTION
- Adds `fonts` prop that is passable to SEO component. Could consider separating into its own <Fonts /> component.
- Changed font `link` to load as `preload` instead of `stylesheet` & added `as='font'` to the html node.