### PR TITLE
Allowing for different types of links to be loaded

### DIFF
--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -12,7 +12,9 @@ export default function SEO ({
   fonts
 }) {
   const Fonts = () =>
-    fonts.map(font => <link href={font.url} rel='stylesheet' />)
+    fonts.map((font, i) => (
+      <link href={font.url} rel='stylesheet' key={`font-${i}`} />
+    ))
 
   return (
     <Head>

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -11,7 +11,7 @@ export default function SEO ({
   url,
   links
 }) {
-  const Links = () => links.map(({ props }) => <link {...props} />)
+  const Links = () => links.map(props => <link {...props} />)
 
   return (
     <Head>

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -12,7 +12,7 @@ export default function SEO ({
   fonts
 }) {
   const Fonts = () =>
-    fonts.map(font => <link href={font.url} rel='stylesheet' />)
+    fonts.map(({ url, ...rest }) => <link href={url} {...rest} />)
 
   return (
     <Head>

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -12,7 +12,7 @@ export default function SEO ({
   fonts
 }) {
   const Fonts = () =>
-    fonts.map(font => <link href={font.url} rel='preload' as='font' />)
+    fonts.map(font => <link href={font.url} rel='stylesheet' />)
 
   return (
     <Head>

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -9,10 +9,9 @@ export default function SEO ({
   favicon,
   ogImage,
   url,
-  fonts
+  links
 }) {
-  const Fonts = () =>
-    fonts.map(({ url, ...rest }) => <link href={url} {...rest} />)
+  const Links = () => links.map(({ props }) => <link {...props} />)
 
   return (
     <Head>
@@ -20,7 +19,7 @@ export default function SEO ({
 
       <link rel='icon' href={favicon} />
 
-      <Fonts />
+      <Links />
 
       <meta property='og:title' content={title} />
       <meta property='og:description' content={description} />

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -9,9 +9,10 @@ export default function SEO ({
   favicon,
   ogImage,
   url,
-  links
+  fonts
 }) {
-  const Links = () => links.map(props => <link {...props} />)
+  const Fonts = () =>
+    fonts.map(font => <link href={font.url} rel='stylesheet' />)
 
   return (
     <Head>
@@ -19,7 +20,7 @@ export default function SEO ({
 
       <link rel='icon' href={favicon} />
 
-      <Links />
+      <Fonts />
 
       <meta property='og:title' content={title} />
       <meta property='og:description' content={description} />

--- a/src/site.config.js
+++ b/src/site.config.js
@@ -11,7 +11,15 @@ export default {
   fonts: [
     {
       url:
-        'https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap'
+        'https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap',
+      rel: 'stylesheet'
     }
+    /* an example of a none stylesheet font you just want to preload
+    {
+      url: 'https://myhosting/SomeFont.woff',
+      rel: 'preload',
+      as: 'font'
+    }
+    */
   ]
 }

--- a/src/site.config.js
+++ b/src/site.config.js
@@ -8,25 +8,10 @@ export default {
   favicon: '/favicon.png',
   ogImage: '/ogImage.png',
   url: 'https://next-mdx.warner.codes',
-  links: [
+  fonts: [
     {
-      href:
-        'https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap',
-      rel: 'stylesheet'
+      url:
+        'https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap'
     }
-    /* an example of a none stylesheet font you just want to preload
-    {
-      href: 'https://myhosting/SomeFont.woff',
-      rel: 'preload',
-      as: 'font'
-    }
-    */
-    /* an example of some remote JS to load in
-    {
-      href: 'https://myhosting/someScript.js,
-      rel: 'preload',
-      as: 'script
-    } 
-   */
   ]
 }

--- a/src/site.config.js
+++ b/src/site.config.js
@@ -8,18 +8,25 @@ export default {
   favicon: '/favicon.png',
   ogImage: '/ogImage.png',
   url: 'https://next-mdx.warner.codes',
-  fonts: [
+  links: [
     {
-      url:
+      href:
         'https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap',
       rel: 'stylesheet'
     }
     /* an example of a none stylesheet font you just want to preload
     {
-      url: 'https://myhosting/SomeFont.woff',
+      href: 'https://myhosting/SomeFont.woff',
       rel: 'preload',
       as: 'font'
     }
     */
+    /* an example of some remote JS to load in
+    {
+      href: 'https://myhosting/someScript.js,
+      rel: 'preload',
+      as: 'script
+    } 
+   */
   ]
 }


### PR DESCRIPTION
I realized that google APIs actually provides a CSS stylesheet so I converted back to that. Some fonts can be loaded as a woff2 or something else. At the same time someone may want to load a custom script. Thus I decided to swap to a `links` prop instead and allow full control over what is passed.

I did leave the favIcon as its own prop / link to make sure it doesn't get removed accidentally.

Let me know your thoughts 🙌 