### PR TITLE
fixing issue with media queries not working properly due to no viewport metatag

### DIFF
--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -30,6 +30,7 @@ export default function SEO ({
       <meta name='twitter:site' content={twitterHandle} />
       <meta name='twitter:card' content='summary_large_image' />
       <meta name='twitter:image' content={`${url}${ogImage}`} />
+      <meta name='viewport' content='width=device-width, initial-scale=1.0' />
     </Head>
   )
 }


### PR DESCRIPTION
The media query for max-width wasn't working so I investigated, turns out it's not supported out of the box:
https://github.com/vercel/next.js/issues/5122